### PR TITLE
chore: scaffold sitepulse monorepo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL="postgresql://postgres:example@localhost:5432/postgres"
+REDIS_URL="redis://localhost:6379"
+PSI_API_KEY=""
+JWT_SECRET="changeme"
+ALLOWED_FETCH_CIDR="0.0.0.0/0"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# bansidhartigga
+# SitePulse
+
+SitePulse is a simplified monorepo skeleton for an SEO auditing and schema generation platform.
+
+## Structure
+
+- `apps/web` – Next.js frontend.
+- `apps/api` – Express API.
+- `apps/worker` – BullMQ worker.
+- `packages/analyzers` – Reusable analysis functions.
+- `packages/ui` – Shared UI components.
+- `prisma` – Prisma schema and seed script.
+
+## Development
+
+```bash
+npm install
+npm test
+```
+
+Run services locally using Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust as needed.
+
+## Notes
+
+This project is a minimal scaffold. Many features from the specification are not fully implemented.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+CMD ["node", "dist/main.js"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "zod": "^3.22.4",
+    "cors": "^2.8.5",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "bcryptjs": "^2.4.3"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/cors": "^2.8.15",
+    "@types/bcryptjs": "^2.4.2",
+    "ts-node": "^10.9.1"
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,39 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { z } from 'zod';
+
+const app = express();
+app.use(cors());
+app.use(helmet());
+app.use(express.json());
+
+app.post('/api/auth/login', (req, res) => {
+  res.json({ token: 'stub' });
+});
+
+app.post('/api/audits/start', (req, res) => {
+  const schema = z.object({ projectId: z.string(), url: z.string().url(), mode: z.enum(['single','crawl']).default('single') });
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json(parsed.error);
+  res.json({ auditId: 'placeholder' });
+});
+
+app.get('/api/audits/:auditId/status', (req, res) => {
+  res.json({ status: 'pending' });
+});
+
+app.get('/api/audits/:auditId/report', (req, res) => {
+  res.json({ score: 0, issues: [] });
+});
+
+app.post('/api/schema/generate', (req, res) => {
+  res.json({ jsonld: {} });
+});
+
+app.post('/api/schema/validate', (req, res) => {
+  res.json({ valid: true, errors: [] });
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => console.log(`API running on port ${port}`));

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json next.config.js tailwind.config.js ./
+RUN npm install
+COPY app ./app
+RUN npm run build
+CMD ["npm", "start"]

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">SitePulse</h1>
+      <p>Welcome to SitePulse. Backend API not fully implemented.</p>
+    </main>
+  );
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.3.3",
+    "tailwindcss": "^3.3.0"
+  }
+}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["next-env.d.ts", "app/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+CMD ["node", "dist/main.js"]

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "worker",
+  "version": "0.1.0",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js"
+  },
+  "dependencies": {
+    "bullmq": "^4.7.0",
+    "ioredis": "^5.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.4.2"
+  }
+}

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,0 +1,13 @@
+import { Queue, Worker } from 'bullmq';
+import { checkTitle } from '@sitepulse/analyzers';
+
+const connection = { connection: { host: 'redis', port: 6379 } };
+
+export const auditQueue = new Queue('audits', connection);
+
+new Worker('audits', async job => {
+  const { html } = job.data;
+  return { title: checkTitle(html) };
+}, connection);
+
+console.log('Worker started');

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.9'
+services:
+  api:
+    build: ./apps/api
+    ports:
+      - "3001:3001"
+    depends_on:
+      - postgres
+      - redis
+  web:
+    build: ./apps/web
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api
+  worker:
+    build: ./apps/worker
+    depends_on:
+      - redis
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: example
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "sitepulse-monorepo",
+  "private": true,
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "build": "npm run build -w apps/web && npm run build -w apps/api && npm run build -w apps/worker",
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "vitest": "^1.1.0"
+  }
+}

--- a/packages/analyzers/package.json
+++ b/packages/analyzers/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@sitepulse/analyzers",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "zod": "^3.22.4",
+    "cheerio": "^1.0.0-rc.12"
+  }
+}

--- a/packages/analyzers/src/index.ts
+++ b/packages/analyzers/src/index.ts
@@ -1,0 +1,14 @@
+import { load } from 'cheerio';
+
+export interface CheckResult {
+  passed: boolean;
+  weight: number;
+  message: string;
+}
+
+export function checkTitle(html: string, maxLength = 60): CheckResult {
+  const $ = load(html);
+  const title = $('title').text();
+  if (!title) return { passed: false, weight: 1, message: 'Missing <title>' };
+  return { passed: title.length <= maxLength, weight: 1, message: `Title length: ${title.length}` };
+}

--- a/packages/analyzers/tsconfig.json
+++ b/packages/analyzers/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@sitepulse/ui",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: React.ReactNode;
+};
+
+export const Button: React.FC<ButtonProps> = ({ children, ...props }) => (
+  <button className="px-4 py-2 bg-blue-600 text-white" {...props}>
+    {children}
+  </button>
+);
+
+export default Button;

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,55 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id       String   @id @default(uuid())
+  email    String   @unique
+  password String
+  projects Project[]
+}
+
+model Project {
+  id        String   @id @default(uuid())
+  name      String
+  owner     User     @relation(fields: [ownerId], references: [id])
+  ownerId   String
+  audits    Audit[]
+}
+
+model Audit {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  project   Project  @relation(fields: [projectId], references: [id])
+  projectId String
+  pages     Page[]
+}
+
+model Page {
+  id        String   @id @default(uuid())
+  url       String
+  audit     Audit    @relation(fields: [auditId], references: [id])
+  auditId   String
+  checks    CheckResult[]
+}
+
+model CheckResult {
+  id      String @id @default(uuid())
+  page    Page   @relation(fields: [pageId], references: [id])
+  pageId  String
+  passed  Boolean
+  weight  Int
+  message String
+}
+
+model SchemaSnippet {
+  id        String   @id @default(uuid())
+  project   Project? @relation(fields: [projectId], references: [id])
+  projectId String?
+  content   String
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  const user = await prisma.user.create({ data: { email: 'demo@sitepulse.dev', password: 'hashed' } });
+  await prisma.project.create({ data: { name: 'Demo Project', ownerId: user.id } });
+}
+
+main().finally(() => prisma.$disconnect());

--- a/tests/analyzers.test.ts
+++ b/tests/analyzers.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { checkTitle } from '../packages/analyzers/src/index';
+
+describe('checkTitle', () => {
+  it('detects missing title', () => {
+    const res = checkTitle('<html></html>');
+    expect(res.passed).toBe(false);
+  });
+  it('passes valid title', () => {
+    const res = checkTitle('<html><title>Hello</title></html>');
+    expect(res.passed).toBe(true);
+  });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- set up minimal SitePulse monorepo with web, api, worker apps
- add analyzers and UI packages
- define prisma schema and docker-compose

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c6548ac88328b3b5f4479010676c